### PR TITLE
Prevent timeout on reaching keyserver in some ubuntus

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,7 +5,7 @@ case node['platform']
     apt_repository 'logentries' do
       uri 'http://rep.logentries.com/'
       components ['precise', 'main']
-      keyserver 'pgp.mit.edu'
+      keyserver 'hkp://pgp.mit.edu:80'
       key 'C43C79AD'
     end
   when "amazon"
@@ -20,7 +20,7 @@ case node['platform']
 end
 
 
-package 'logentries' 
+package 'logentries'
 package 'logentries-daemon' do
   action :nothing
 end


### PR DESCRIPTION
So I have a strange issue with all my ubuntu VMs that they won't find any keyserver that is missing port and protocol.

This ensures that all ubuntus can find the keyserver
